### PR TITLE
Feature remove submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "src/python/qt_py_convert/external/Qt_py"]
-	path = src/python/qt_py_convert/external/Qt_py
-	url = git@github.com:digitaldomain/Qt.py.git

--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ Redbaron allows us to modify the source code and write it back out again, preser
 pip install redbaron
 ```
 
+We also provide a requirements.txt file which you could install instead by...  
+```
+pip install -r requirements.txt
+```
+
 You should also have access to any of your source bindings so that Qy.py can import them freely.  
 
 A full list of dependencies is as follows:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+Qt.py>=1.2.0.b2
+redbaron

--- a/src/python/qt_py_convert/__init__.py
+++ b/src/python/qt_py_convert/__init__.py
@@ -19,7 +19,7 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied. See the Apache License for the specific
 # language governing permissions and limitations under the Apache License.
-__version__ = "3.0.0"
+__version__ = "3.1.0"
 """
 An automatic Python Qt binding transpiler to the Qt.py abstraction layer. 
 It aims to help in your modernization of your Python Qt code. 

--- a/src/python/qt_py_convert/external/__init__.py
+++ b/src/python/qt_py_convert/external/__init__.py
@@ -1,3 +1,0 @@
-# This is a temp hac until we can either stand up our own patched Qt.py
-#   or get these changes merged into mottosso/master.
-from Qt_py import Qt

--- a/src/python/qt_py_convert/general.py
+++ b/src/python/qt_py_convert/general.py
@@ -27,10 +27,12 @@ import json
 import os
 import re
 
+import Qt
+
 from qt_py_convert.color import ANSI, color_text
 from qt_py_convert.diff import highlight_diffs
 from qt_py_convert.log import get_logger
-from qt_py_convert.external import Qt
+
 
 GENERAL_LOGGER = get_logger("general", name_color=ANSI.colors.green)
 

--- a/src/python/qt_py_convert/mappings.py
+++ b/src/python/qt_py_convert/mappings.py
@@ -21,7 +21,8 @@
 # language governing permissions and limitations under the Apache License.
 import re
 
-from qt_py_convert.external import Qt
+import Qt
+
 from qt_py_convert.log import get_logger
 from qt_py_convert.general import _custom_misplaced_members
 

--- a/src/python/qt_py_convert/run.py
+++ b/src/python/qt_py_convert/run.py
@@ -25,7 +25,11 @@ import sys
 import traceback
 
 
-from qt_py_convert.external import Qt
+import Qt
+if Qt.__version__ < "1.2.0.b2":
+    raise ImportError(
+        "Improper Qt.py version installed. Qt.py must be version 1.2.0.b2 or above.
+    )
 import redbaron
 
 from qt_py_convert._modules import from_imports

--- a/tests/test_psep0101/test_qvariant.py
+++ b/tests/test_psep0101/test_qvariant.py
@@ -1,5 +1,5 @@
 from qt_py_convert._modules.psep0101 import process
-from qt_py_convert.external.redbaron import redbaron
+from redbaron import redbaron
 from qt_py_convert.general import ALIAS_DICT
 
 


### PR DESCRIPTION
Removing the qt_py_convert.external subpackage and all references to it within the code.

This is being done because Qt.py fully supports our changeset now. It has been merged in at release 1.2.0.b2.

