### PR TITLE
Fixing a logic error on the path output code

### DIFF
--- a/src/python/qt_py_convert/run.py
+++ b/src/python/qt_py_convert/run.py
@@ -577,7 +577,7 @@ def process_file(fp, write_mode=None, path=None, backup=False, skip_lineno=False
             if write_mode & WriteFlag.WRITE_TO_STDOUT:
                 sys.stdout.write(modified_code)
             else:
-                if path:  # We are writing elsewhere than the source.
+                if path and path[0]:  # We are writing elsewhere than the source.
                     src_root, dst_root = path
                     root_relative = fp.replace(src_root, "").lstrip("/")
                     write_path = os.path.join(dst_root, root_relative)


### PR DESCRIPTION
Found this error in Windows but should exist for Linux too I'd imagine.